### PR TITLE
feat: Improve Home screen design and implement navigation

### DIFF
--- a/lib/core/router/router.dart
+++ b/lib/core/router/router.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:ocean_card/presentation/views/card/card_view.dart';
+import 'package:ocean_card/presentation/views/actions/actions.dart';
 
 import '../../navegador.dart';
 import '../../presentation/views/home/home_view.dart';
@@ -43,6 +44,54 @@ GoRouter createAppRouter() {
             path: '/card',
             pageBuilder: (context, state) {
               return customTransitionPage(const CardView(), state);
+            },
+          ),
+          GoRoute(
+            path: '/deposit',
+            pageBuilder: (context, state) {
+              return customTransitionPage(const DepositView(), state);
+            },
+          ),
+          GoRoute(
+            path: '/exchange',
+            pageBuilder: (context, state) {
+              return customTransitionPage(const ExchangeView(), state);
+            },
+          ),
+          GoRoute(
+            path: '/withdraw',
+            pageBuilder: (context, state) {
+              return customTransitionPage(const WithdrawView(), state);
+            },
+          ),
+          GoRoute(
+            path: '/cvu',
+            pageBuilder: (context, state) {
+              return customTransitionPage(const CvuView(), state);
+            },
+          ),
+          GoRoute(
+            path: '/add-funds',
+            pageBuilder: (context, state) {
+              return customTransitionPage(const AddFundsView(), state);
+            },
+          ),
+          GoRoute(
+            path: '/transfer',
+            pageBuilder: (context, state) {
+              return customTransitionPage(const TransferView(), state);
+            },
+          ),
+          GoRoute(
+            path: '/buy-sell',
+            pageBuilder: (context, state) {
+              return customTransitionPage(const BuySellView(), state);
+            },
+          ),
+          GoRoute(
+            path: '/earn-money',
+            pageBuilder: (context, state) {
+              return customTransitionPage(const EarnMoneyView(), state);
             },
           ),
         ],

--- a/lib/presentation/views/actions/actions.dart
+++ b/lib/presentation/views/actions/actions.dart
@@ -1,0 +1,8 @@
+export 'deposit_view.dart';
+export 'exchange_view.dart';
+export 'withdraw_view.dart';
+export 'cvu_view.dart';
+export 'add_funds_view.dart';
+export 'transfer_view.dart';
+export 'buy_sell_view.dart';
+export 'earn_money_view.dart';

--- a/lib/presentation/views/actions/add_funds_view.dart
+++ b/lib/presentation/views/actions/add_funds_view.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class AddFundsView extends StatelessWidget {
+  const AddFundsView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Add Funds'),
+      ),
+      body: const Center(
+        child: Text('Add Funds View - Coming Soon!'),
+      ),
+    );
+  }
+}

--- a/lib/presentation/views/actions/buy_sell_view.dart
+++ b/lib/presentation/views/actions/buy_sell_view.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class BuySellView extends StatelessWidget {
+  const BuySellView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Buy & Sell'),
+      ),
+      body: const Center(
+        child: Text('Buy & Sell View - Coming Soon!'),
+      ),
+    );
+  }
+}

--- a/lib/presentation/views/actions/cvu_view.dart
+++ b/lib/presentation/views/actions/cvu_view.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class CvuView extends StatelessWidget {
+  const CvuView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('CVU'),
+      ),
+      body: const Center(
+        child: Text('CVU View - Coming Soon!'),
+      ),
+    );
+  }
+}

--- a/lib/presentation/views/actions/deposit_view.dart
+++ b/lib/presentation/views/actions/deposit_view.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class DepositView extends StatelessWidget {
+  const DepositView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Deposit'),
+      ),
+      body: const Center(
+        child: Text('Deposit View - Coming Soon!'),
+      ),
+    );
+  }
+}

--- a/lib/presentation/views/actions/earn_money_view.dart
+++ b/lib/presentation/views/actions/earn_money_view.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class EarnMoneyView extends StatelessWidget {
+  const EarnMoneyView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Earn Money'),
+      ),
+      body: const Center(
+        child: Text('Earn Money View - Coming Soon!'),
+      ),
+    );
+  }
+}

--- a/lib/presentation/views/actions/exchange_view.dart
+++ b/lib/presentation/views/actions/exchange_view.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class ExchangeView extends StatelessWidget {
+  const ExchangeView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Exchange'),
+      ),
+      body: const Center(
+        child: Text('Exchange View - Coming Soon!'),
+      ),
+    );
+  }
+}

--- a/lib/presentation/views/actions/transfer_view.dart
+++ b/lib/presentation/views/actions/transfer_view.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class TransferView extends StatelessWidget {
+  const TransferView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Transfer'),
+      ),
+      body: const Center(
+        child: Text('Transfer View - Coming Soon!'),
+      ),
+    );
+  }
+}

--- a/lib/presentation/views/actions/withdraw_view.dart
+++ b/lib/presentation/views/actions/withdraw_view.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class WithdrawView extends StatelessWidget {
+  const WithdrawView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Withdraw'),
+      ),
+      body: const Center(
+        child: Text('Withdraw View - Coming Soon!'),
+      ),
+    );
+  }
+}

--- a/lib/presentation/views/home/home_view.dart
+++ b/lib/presentation/views/home/home_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'widgets/home_action_card.dart';
 import 'widgets/quick_action_button.dart';
 
@@ -131,9 +132,7 @@ class _HomeViewState extends State<HomeView> {
                           SizedBox(
                             width: double.infinity,
                             child: ElevatedButton.icon(
-                              onPressed: () {
-                                // Add funds action
-                              },
+                              onPressed: () => context.go('/add-funds'),
                               icon: const Icon(Icons.add, color: Colors.white),
                               label: const Text(
                                 'Add funds',
@@ -212,25 +211,25 @@ class _HomeViewState extends State<HomeView> {
                             icon: Icons.download,
                             label: 'Deposit',
                             color: Colors.white,
-                            onTap: () {},
+                            onTap: () => context.go('/deposit'),
                           ),
                           QuickActionButton(
                             icon: Icons.swap_horiz,
                             label: 'Exchange',
                             color: Colors.white,
-                            onTap: () {},
+                            onTap: () => context.go('/exchange'),
                           ),
                           QuickActionButton(
                             icon: Icons.upload,
                             label: 'Withdraw',
                             color: Colors.white,
-                            onTap: () {},
+                            onTap: () => context.go('/withdraw'),
                           ),
                           QuickActionButton(
                             icon: Icons.credit_card,
                             label: 'Your CVU',
                             color: Colors.white,
-                            onTap: () {},
+                            onTap: () => context.go('/cvu'),
                           ),
                         ],
                       ),
@@ -264,28 +263,28 @@ class _HomeViewState extends State<HomeView> {
                             title: 'Transfer',
                             icon: Icons.sync_alt,
                             description: 'Transfer your funds',
-                            onTap: () {},
+                            onTap: () => context.go('/transfer'),
                             colorScheme: colorScheme,
                           ),
                           HomeActionCard(
                             title: 'Buy & Sell',
                             icon: Icons.swap_horiz,
                             description: 'Buy and sell assets',
-                            onTap: () {},
+                            onTap: () => context.go('/buy-sell'),
                             colorScheme: colorScheme,
                           ),
                           HomeActionCard(
                             title: 'Ocean Card',
-                            icon: Icons.credit_card,
+                            svgIconPath: 'assets/card_black.svg',
                             description: 'Manage your card',
-                            onTap: () {},
+                            onTap: () => context.go('/card'),
                             colorScheme: colorScheme,
                           ),
                           HomeActionCard(
                             title: 'Earn Money',
                             icon: Icons.monetization_on,
                             description: 'Invite and earn rewards',
-                            onTap: () {},
+                            onTap: () => context.go('/earn-money'),
                             colorScheme: colorScheme,
                           ),
                         ],

--- a/lib/presentation/views/home/widgets/home_action_card.dart
+++ b/lib/presentation/views/home/widgets/home_action_card.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 
 class HomeActionCard extends StatelessWidget {
   final String title;
   final IconData icon;
+  final String? svgIconPath;
   final String description;
   final VoidCallback onTap;
   final ColorScheme colorScheme;
@@ -11,6 +13,7 @@ class HomeActionCard extends StatelessWidget {
     super.key,
     required this.title,
     required this.icon,
+    this.svgIconPath,
     required this.description,
     required this.onTap,
     required this.colorScheme,
@@ -51,7 +54,17 @@ class HomeActionCard extends StatelessWidget {
               // Central icon
               Expanded(
                 child: Center(
-                  child: Icon(icon, size: 56, color: colorScheme.primary),
+                  child: svgIconPath != null && svgIconPath!.isNotEmpty
+                      ? SvgPicture.asset(
+                          svgIconPath!,
+                          width: 56,
+                          height: 56,
+                          colorFilter: ColorFilter.mode(
+                            colorScheme.primary,
+                            BlendMode.srcIn,
+                          ),
+                        )
+                      : Icon(icon, size: 56, color: colorScheme.primary),
                 ),
               ),
               // Bottom description

--- a/test/presentation/views/home/home_view_test.dart
+++ b/test/presentation/views/home/home_view_test.dart
@@ -1,0 +1,157 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:ocean_card/presentation/views/home/home_view.dart';
+import 'package:ocean_card/presentation/views/home/widgets/home_action_card.dart';
+import 'package:ocean_card/presentation/views/home/widgets/quick_action_button.dart';
+
+// Mock GoRouter
+class MockGoRouter extends GoRouter {
+  MockGoRouter({required List<RouteBase> routes})
+      : super(routes: routes, initialLocation: '/'); // Ensure initialLocation is set
+
+  String? lastNavigatedPath;
+
+  @override
+  Future<T?> push<T extends Object?>(String location, {Object? extra}) {
+    lastNavigatedPath = location;
+    return Future.value(null);
+  }
+
+  @override
+  void go(String location, {Object? extra}) {
+    lastNavigatedPath = location;
+  }
+}
+
+// Test utility
+Widget createTestableWidget({required Widget child, required GoRouter router}) {
+  return MaterialApp(
+    home: InheritedGoRouter(
+      goRouter: router,
+      child: child,
+    ),
+  );
+}
+
+void main() {
+  late MockGoRouter mockRouter;
+
+  setUp(() {
+    // Define a basic route for the home view itself, and any other needed for initialization
+    mockRouter = MockGoRouter(routes: [
+      GoRoute(path: '/', builder: (_, __) => const HomeView()), // Mock for initial route
+      GoRoute(path: '/add-funds', builder: (_, __) => Container()),
+      GoRoute(path: '/deposit', builder: (_, __) => Container()),
+      GoRoute(path: '/exchange', builder: (_, __) => Container()),
+      GoRoute(path: '/withdraw', builder: (_, __) => Container()),
+      GoRoute(path: '/cvu', builder: (_, __) => Container()),
+      GoRoute(path: '/transfer', builder: (_, __) => Container()),
+      GoRoute(path: '/buy-sell', builder: (_, __) => Container()),
+      GoRoute(path: '/card', builder: (_, __) => Container()),
+      GoRoute(path: '/earn-money', builder: (_, __) => Container()),
+    ]);
+  });
+
+  // Helper to pump HomeView with the mock router
+  Future<void> pumpHomeView(WidgetTester tester) async {
+    await tester.pumpWidget(
+      createTestableWidget(child: const HomeView(), router: mockRouter),
+    );
+    // SvgPicture.asset might need this if it tries to load real assets.
+    // For now, we are not directly testing SVG rendering, so this might not be strictly needed,
+    // but good practice if assets were involved in rendering.
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('tapping Add Funds button navigates to /add-funds', (WidgetTester tester) async {
+    await pumpHomeView(tester);
+
+    final addFundsButton = find.widgetWithText(ElevatedButton, 'Add funds');
+    expect(addFundsButton, findsOneWidget);
+
+    await tester.tap(addFundsButton);
+    await tester.pumpAndSettle();
+
+    expect(mockRouter.lastNavigatedPath, '/add-funds');
+  });
+
+  // QuickActionButtons
+  testWidgets('tapping Deposit QuickActionButton navigates to /deposit', (WidgetTester tester) async {
+    await pumpHomeView(tester);
+    final button = find.widgetWithText(QuickActionButton, 'Deposit');
+    expect(button, findsOneWidget);
+    await tester.tap(button);
+    await tester.pumpAndSettle();
+    expect(mockRouter.lastNavigatedPath, '/deposit');
+  });
+
+  testWidgets('tapping Exchange QuickActionButton navigates to /exchange', (WidgetTester tester) async {
+    await pumpHomeView(tester);
+    final button = find.widgetWithText(QuickActionButton, 'Exchange');
+    expect(button, findsOneWidget);
+    await tester.tap(button);
+    await tester.pumpAndSettle();
+    expect(mockRouter.lastNavigatedPath, '/exchange');
+  });
+
+  testWidgets('tapping Withdraw QuickActionButton navigates to /withdraw', (WidgetTester tester) async {
+    await pumpHomeView(tester);
+    final button = find.widgetWithText(QuickActionButton, 'Withdraw');
+    expect(button, findsOneWidget);
+    await tester.tap(button);
+    await tester.pumpAndSettle();
+    expect(mockRouter.lastNavigatedPath, '/withdraw');
+  });
+
+  testWidgets('tapping Your CVU QuickActionButton navigates to /cvu', (WidgetTester tester) async {
+    await pumpHomeView(tester);
+    final button = find.widgetWithText(QuickActionButton, 'Your CVU');
+    expect(button, findsOneWidget);
+    await tester.tap(button);
+    await tester.pumpAndSettle();
+    expect(mockRouter.lastNavigatedPath, '/cvu');
+  });
+
+  // HomeActionCards
+  testWidgets('tapping Transfer HomeActionCard navigates to /transfer', (WidgetTester tester) async {
+    await pumpHomeView(tester);
+    // We find by the title text within the HomeActionCard
+    final card = find.widgetWithText(HomeActionCard, 'Transfer');
+    expect(card, findsOneWidget);
+    await tester.tap(card);
+    await tester.pumpAndSettle();
+    expect(mockRouter.lastNavigatedPath, '/transfer');
+  });
+
+  testWidgets('tapping Buy & Sell HomeActionCard navigates to /buy-sell', (WidgetTester tester) async {
+    await pumpHomeView(tester);
+    final card = find.widgetWithText(HomeActionCard, 'Buy & Sell');
+    expect(card, findsOneWidget);
+    await tester.tap(card);
+    await tester.pumpAndSettle();
+    expect(mockRouter.lastNavigatedPath, '/buy-sell');
+  });
+
+  testWidgets('tapping Ocean Card HomeActionCard navigates to /card', (WidgetTester tester) async {
+    await pumpHomeView(tester);
+    final card = find.widgetWithText(HomeActionCard, 'Ocean Card');
+    expect(card, findsOneWidget);
+
+    // The HomeActionCard itself is what we tap, not a child Text widget.
+    await tester.tap(find.byWidgetPredicate(
+      (widget) => widget is HomeActionCard && widget.title == 'Ocean Card'
+    ));
+    await tester.pumpAndSettle();
+    expect(mockRouter.lastNavigatedPath, '/card');
+  });
+
+  testWidgets('tapping Earn Money HomeActionCard navigates to /earn-money', (WidgetTester tester) async {
+    await pumpHomeView(tester);
+    final card = find.widgetWithText(HomeActionCard, 'Earn Money');
+    expect(card, findsOneWidget);
+    await tester.tap(card);
+    await tester.pumpAndSettle();
+    expect(mockRouter.lastNavigatedPath, '/earn-money');
+  });
+}

--- a/test/presentation/views/home/widgets/home_action_card_test.dart
+++ b/test/presentation/views/home/widgets/home_action_card_test.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ocean_card/presentation/views/home/widgets/home_action_card.dart';
+
+void main() {
+  // Define a dummy ColorScheme to pass to the widget
+  const ColorScheme colorScheme = ColorScheme.light();
+
+  testWidgets('Displays IconData when svgIconPath is null', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: HomeActionCard(
+            title: 'Test Card',
+            icon: Icons.home,
+            description: 'Test Description',
+            onTap: () {},
+            colorScheme: colorScheme,
+            svgIconPath: null,
+          ),
+        ),
+      ),
+    );
+
+    // Verify that an Icon widget is found for the main icon.
+    // We expect two Icon widgets: one for the main icon and one for the chevron_right.
+    // So we look for the one that is not chevron_right.
+    expect(find.byWidgetPredicate((widget) => widget is Icon && widget.icon == Icons.home), findsOneWidget);
+    expect(find.byType(SvgPicture), findsNothing);
+  });
+
+  testWidgets('Displays SvgPicture when svgIconPath is provided', (WidgetTester tester) async {
+    // For SvgPicture.asset to work in tests, we need to ensure assets are available.
+    // This often requires a specific test setup for assets, or mocking.
+    // For now, we'll assume the test environment can handle it or we're checking type.
+    // If 'assets/card_black.svg' is not found during test, this test might fail
+    // not because of widget logic but due to asset loading.
+    // A more robust way would involve using a TestAssetBundle.
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: HomeActionCard(
+            title: 'Test SVG Card',
+            icon: Icons.error, // Fallback icon, should not be displayed
+            svgIconPath: 'assets/card_black.svg', // Dummy path
+            description: 'Test SVG Description',
+            onTap: () {},
+            colorScheme: colorScheme,
+          ),
+        ),
+      ),
+    );
+
+    // We need to ensure that the SvgPicture is found.
+    // The actual rendering of an SVG from a path in a test environment can be tricky.
+    // flutter_svg_test package can be used for more robust SvgPicture testing.
+    // For now, we check if SvgPicture widget is in the tree.
+    expect(find.byType(SvgPicture), findsOneWidget);
+
+    // Verify that the fallback Icon widget (Icons.error) is NOT found for the main icon.
+    // The chevron_right icon will still be present.
+    expect(find.byWidgetPredicate((widget) => widget is Icon && widget.icon == Icons.error), findsNothing);
+  });
+
+  testWidgets('Calls onTap when tapped', (WidgetTester tester) async {
+    bool tapped = false;
+    VoidCallback mockOnTap = () {
+      tapped = true;
+    };
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: HomeActionCard(
+            title: 'Tap Test Card',
+            icon: Icons.touch_app,
+            description: 'Tap Test Description',
+            onTap: mockOnTap,
+            colorScheme: colorScheme,
+          ),
+        ),
+      ),
+    );
+
+    // Find the card (InkWell is part of HomeActionCard's implementation)
+    expect(find.byType(InkWell), findsOneWidget);
+    
+    // Simulate a tap on the card
+    await tester.tap(find.byType(InkWell));
+    await tester.pump(); // Process the tap
+
+    // Verify that the mock callback was called once
+    expect(tapped, isTrue);
+  });
+}


### PR DESCRIPTION
This commit introduces several improvements to the Home screen:

- Updates the 'Ocean Card' to use a new black SVG icon (`card_black.svg`) instead of the previous `Icons.credit_card`.
- Modifies the `HomeActionCard` widget to support displaying either an `IconData` or an SVG image via a new `svgIconPath` parameter.
- Implements navigation for all action items on the home screen. Placeholder views (`DepositView`, `ExchangeView`, etc.) have been created for each action, and tapping the corresponding button or card now navigates to the respective view.
    - Add Funds button -> `/add-funds`
    - Deposit button -> `/deposit`
    - Exchange button -> `/exchange`
    - Withdraw button -> `/withdraw`
    - Your CVU button -> `/cvu`
    - Transfer card -> `/transfer`
    - Buy & Sell card -> `/buy-sell`
    - Ocean Card -> `/card` (navigates to existing card management view)
    - Earn Money card -> `/earn-money`
- Adds widget tests for `HomeActionCard` to verify correct icon (SVG or IconData) rendering and `onTap` functionality.
- Adds widget tests for `HomeView` to verify that all implemented navigation actions trigger correctly.